### PR TITLE
micalg: convert raw micalg to lowercase for map lookup

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -228,6 +228,7 @@ func (r *signedReader) check() error {
 }
 
 func newSignedReader(h textproto.Header, mr *textproto.MultipartReader, micalg string, keyring openpgp.KeyRing, prompt openpgp.PromptFunction, config *packet.Config) (*Reader, error) {
+	micalg = strings.ToLower(micalg)
 	hashFunc, ok := hashAlgs[micalg]
 	if !ok {
 		return nil, fmt.Errorf("pgpmail: unsupported micalg %q", micalg)

--- a/reader_test.go
+++ b/reader_test.go
@@ -248,7 +248,7 @@ iTk5F8GSyv30EXnqvrs=
 var testPGPMIMESigned = toCRLF(`From: John Doe <john.doe@example.org>
 To: John Doe <john.doe@example.org>
 Mime-Version: 1.0
-Content-Type: multipart/signed; boundary=bar; micalg=pgp-sha256;
+Content-Type: multipart/signed; boundary=bar; micalg=pgp-SHA256;
    protocol="application/pgp-signature"
 
 --bar


### PR DESCRIPTION
Some mail clients send micalg values in uppercase. The current
implementation doesn't allow for anything other than lowercase.

The referenced table (RFC4880 9.4) lists the algorithms in uppercase, so
it's reasonable that a client would send a micalg in something other
than lowercase.

This patch converts the raw micalg to lowercase, and modifies a test
case to have an uppercase micalg.

Signed-off-by: Tim Culverhouse <tim@timculverhouse.com>