### PR TITLE
Ensure Mime-Version is set on the right header

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -41,6 +41,10 @@ func Encrypt(w io.Writer, h textproto.Header, to []*openpgp.Entity, signed *open
 	}
 	h.Set("Content-Type", mime.FormatMediaType("multipart/encrypted", params))
 
+	if !h.Has("Mime-Version") {
+		h.Set("Mime-Version", "1.0")
+	}
+
 	if err := textproto.WriteHeader(w, h); err != nil {
 		return nil, err
 	}
@@ -70,22 +74,35 @@ func Encrypt(w io.Writer, h textproto.Header, to []*openpgp.Entity, signed *open
 		return nil, err
 	}
 
-	plaintext, err := openpgp.EncryptText(armorWriter, to, signed, nil, config)
-	if err != nil {
-		return nil, err
-	}
+	handleHeader := func(encryptedHeader textproto.Header) (io.WriteCloser, error) {
+		encryptedHeader.Del("Mime-Version")
 
-	return struct {
-		io.Writer
-		io.Closer
-	}{
-		plaintext,
-		multiCloser{
+		plaintext, err := openpgp.EncryptText(armorWriter, to, signed, nil, config)
+		if err != nil {
+			return nil, err
+		}
+
+		var closer io.Closer = multiCloser{
 			plaintext,
 			armorWriter,
 			mw,
-		},
-	}, nil
+		}
+
+		if err := textproto.WriteHeader(plaintext, encryptedHeader); err != nil {
+			closer.Close()
+			return nil, err
+		}
+
+		return struct {
+			io.Writer
+			io.Closer
+		}{
+			Writer: plaintext,
+			Closer: closer,
+		}, nil
+	}
+
+	return &headerWriter{handle: handleHeader}, nil
 }
 
 type signer struct {
@@ -165,11 +182,17 @@ func Sign(w io.Writer, header textproto.Header, signed *openpgp.Entity, config *
 	}
 	header.Set("Content-Type", mime.FormatMediaType("multipart/signed", params))
 
+	if !header.Has("Mime-Version") {
+		header.Set("Mime-Version", "1.0")
+	}
+
 	if err := textproto.WriteHeader(w, header); err != nil {
 		return nil, err
 	}
 
 	handleHeader := func(signedHeader textproto.Header) (io.WriteCloser, error) {
+		signedHeader.Del("Mime-Version")
+
 		signedWriter, err := mw.CreatePart(signedHeader)
 		if err != nil {
 			return nil, err

--- a/writer_test.go
+++ b/writer_test.go
@@ -119,7 +119,8 @@ func formatMessage(h textproto.Header, body string) string {
 	return sb.String()
 }
 
-var wantEncryptedPrefix = toCRLF(`Content-Type: multipart/encrypted; boundary=foo;
+var wantEncryptedPrefix = toCRLF(`Mime-Version: 1.0
+Content-Type: multipart/encrypted; boundary=foo;
  protocol="application/pgp-encrypted"
 To: John Doe <john.doe@example.org>
 From: John Doe <john.doe@example.org>
@@ -140,7 +141,8 @@ var wantEncryptedSuffix = toCRLF(`
 --foo--
 `)
 
-var wantSignedPrefix = toCRLF(`Content-Type: multipart/signed; boundary=foo; micalg=pgp-sha256;
+var wantSignedPrefix = toCRLF(`Mime-Version: 1.0
+Content-Type: multipart/signed; boundary=foo; micalg=pgp-sha256;
  protocol="application/pgp-signature"
 To: John Doe <john.doe@example.org>
 From: John Doe <john.doe@example.org>


### PR DESCRIPTION
- [x] The nested encrypted part may still contain a `Mime-Version` header field

Closes: https://github.com/emersion/go-pgpmail/issues/14